### PR TITLE
Fix routing issues

### DIFF
--- a/src/front-end/components/About/About.js
+++ b/src/front-end/components/About/About.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const About = () => (
+  <div>
+    <h1>About</h1>
+  </div>
+)
+
+export default About

--- a/src/front-end/components/About/index.js
+++ b/src/front-end/components/About/index.js
@@ -1,0 +1,3 @@
+import About from './About'
+
+export default About

--- a/src/front-end/components/Page/Page.js
+++ b/src/front-end/components/Page/Page.js
@@ -1,18 +1,19 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { Route } from 'react-router-dom'
 import Post from '../Post'
+import About from '../About'
 
 
-const Page = ({postId}) => (
+const Page = () => (
   <section className='col-11 col-lg-9 offset-lg-1 pt-5 mb-5'>
-    <Route exact path={`/posts/${postId}`} render={() => <Post postId={postId} />} />
-    {/* <Route path='/about' component={About} /> */}
+    <Route exact path='/page/about' component={About} />
+    <Route exact path='/posts/react' render={() => <Post postId='react' />} />
+    <Route exact path='/posts/redux' render={() => <Post postId='redux' />} />
+    <Route exact path='/posts/immutable' render={() => <Post postId='immutable' />} />
     {/* <Route path='/project' component={Project} /> */}
   </section>
 )
 
-Page.propTypes = { postId: PropTypes.string }
 
 export default Page
 

--- a/src/front-end/components/Page/Page.js
+++ b/src/front-end/components/Page/Page.js
@@ -7,9 +7,9 @@ import About from '../About'
 const Page = () => (
   <section className='col-11 col-lg-9 offset-lg-1 pt-5 mb-5'>
     <Route exact path='/page/about' component={About} />
-    <Route exact path='/posts/react' render={() => <Post postId='react' />} />
-    <Route exact path='/posts/redux' render={() => <Post postId='redux' />} />
-    <Route exact path='/posts/immutable' render={() => <Post postId='immutable' />} />
+    <Route exact path='/post/react' render={() => <Post postId='react' />} />
+    <Route exact path='/post/redux' render={() => <Post postId='redux' />} />
+    <Route exact path='/post/immutable' render={() => <Post postId='immutable' />} />
     {/* <Route path='/project' component={Project} /> */}
   </section>
 )

--- a/src/front-end/components/PageLayout/PageLayout.js
+++ b/src/front-end/components/PageLayout/PageLayout.js
@@ -1,19 +1,15 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import Sidebar from '../Sidebar'
 import Page from '../Page'
 
-const PageLayout = () => {
-  const [state, setState] = useState({postId: ''})
-
-  return (
-    <div className='container-fluid'>
-      <div className='row'>
-        <Sidebar updateState={setState} />
-        <Page postId={state.postId} />
-      </div>
+const PageLayout = () => (
+  <div className='container-fluid'>
+    <div className='row'>
+      <Sidebar />
+      <Page/>
     </div>
-  )
-}
+  </div>
+)
 
 export default PageLayout

--- a/src/front-end/components/Post/Post.js
+++ b/src/front-end/components/Post/Post.js
@@ -20,7 +20,6 @@ const Post = ({postId}) => {
 
   return (
     <div className='post col-lg-10'>
-      <p>Post ID: {postId}</p>
       <ReactMarkdown source={state} />
     </div>
   )

--- a/src/front-end/components/Post/Post.js
+++ b/src/front-end/components/Post/Post.js
@@ -6,7 +6,7 @@ import './styles.css'
 
 
 const sendRequest = async(postId, updateState) => 
-  await fetch(`/api/posts/${postId}`) // eslint-disable-line no-undef  
+  await fetch(`/api/post/${postId}`) // eslint-disable-line no-undef  
     .then(resp => resp.json())
     .then(data => updateState(data))
 

--- a/src/front-end/components/Sidebar/Sidebar.js
+++ b/src/front-end/components/Sidebar/Sidebar.js
@@ -10,9 +10,9 @@ const Sidebar = () => (
         <LinkItem exact to='/'>Home</LinkItem>
         <LinkItem to='/page/about'>About</LinkItem>
         <LinkItem to='/page/projects'>Projects</LinkItem>
-        <LinkItem to='/posts/react'>React</LinkItem>
-        <LinkItem to='/posts/redux'>Redux</LinkItem>
-        <LinkItem to='/posts/immutable'>Immutable</LinkItem>
+        <LinkItem to='/post/react'>React</LinkItem>
+        <LinkItem to='/post/redux'>Redux</LinkItem>
+        <LinkItem to='/post/immutable'>Immutable</LinkItem>
       </div>
     </div>
   </Bar>

--- a/src/front-end/components/Sidebar/Sidebar.js
+++ b/src/front-end/components/Sidebar/Sidebar.js
@@ -1,32 +1,21 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 import { Bar, LinkItem } from './styles'
 
-// const sendRequest = async(postId, updateState) =>
-//   await fetch(`/api/posts/${postId}`) // eslint-disable-line no-undef  
-//     .then(resp => resp.json()) 
-//     .then(data => updateState({postId, data: JSON.parse(data)}))
 
-const goUpdateState = (updateState, postId) => updateState(postId)
-
-const Sidebar = ({updateState}) => (
+const Sidebar = () => (
   <Bar className='col-lg-2 d-none d-lg-block'>
     <div className='d-flex flex-column'>
       <div className='ml-1 mt-5'>
         <LinkItem exact to='/'>Home</LinkItem>
-        <LinkItem onClick={goUpdateState.bind(this, updateState, {postId: 'about'})} to='/about'>About</LinkItem>
-        <LinkItem onClick={goUpdateState.bind(this, updateState, {postId: 'projects'})} to='/projects'>Projects</LinkItem>
-        <LinkItem onClick={goUpdateState.bind(this, updateState, {postId: 'react'})} to='/posts/react'>React</LinkItem>
-        <LinkItem onClick={goUpdateState.bind(this, updateState, {postId: 'redux'})} to='/posts/redux'>Redux</LinkItem>
-        <LinkItem onClick={goUpdateState.bind(this, updateState, {postId: 'immutable'})} to='/posts/immutable'>Immutable</LinkItem>
+        <LinkItem to='/page/about'>About</LinkItem>
+        <LinkItem to='/page/projects'>Projects</LinkItem>
+        <LinkItem to='/posts/react'>React</LinkItem>
+        <LinkItem to='/posts/redux'>Redux</LinkItem>
+        <LinkItem to='/posts/immutable'>Immutable</LinkItem>
       </div>
     </div>
   </Bar>
 )
-
-Sidebar.propTypes = {
-  updateState: PropTypes.func
-}
 
 export default Sidebar

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -19,20 +19,24 @@ router.get('/api/posts/:postId', (req, res) => {
 })
 
 // Main pages - e.g. /about
-router.get('/:page', (req, res) => { 
+router.get('/page/:page', (req, res) => { 
   console.log('\n-->> 2.', req.params)
   res.sendFile(HTML_FILE) 
 })
 
 // Post pages - e.g. /posts/redux
-router.get('/posts/:page', (req, res) => { 
+router.get('/posts/:post', (req, res) => { 
   console.log('\n-->> 3.', req.params)
   res.sendFile(HTML_FILE) 
 })
 
 // Assets from the Dist folder - e.g. font files
 router.get('*', (req, res) => {
-  console.log('\n-->> 3.', req.params)
+  console.log('-->> 4.', req.params)
+
+  if (req.params['0'] === '/' || req.params['0'].slice(0, 2) === '..')
+    return res.sendFile(HTML_FILE)
+  
   res.sendFile(path.join(DIST_DIR, req.params[0].slice(1)))
 })
 

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -11,7 +11,6 @@ app.use(express.static(DIST_DIR))
 
 // Markdown docs
 router.get('/api/posts/:postId', (req, res) => {
-  console.log('\n-->> 1.', req.params)
   const content = fs.readFileSync(`./src/content/${req.params.postId}.md`, 'utf8')
 
   res.setHeader('Content-Type', 'application/json')
@@ -19,21 +18,13 @@ router.get('/api/posts/:postId', (req, res) => {
 })
 
 // Main pages - e.g. /about
-router.get('/page/:page', (req, res) => { 
-  console.log('\n-->> 2.', req.params)
-  res.sendFile(HTML_FILE) 
-})
+router.get('/page/:page', (req, res) => { res.sendFile(HTML_FILE) })
 
 // Post pages - e.g. /posts/redux
-router.get('/posts/:post', (req, res) => { 
-  console.log('\n-->> 3.', req.params)
-  res.sendFile(HTML_FILE) 
-})
+router.get('/posts/:post', (req, res) => { res.sendFile(HTML_FILE) })
 
 // Assets from the Dist folder - e.g. font files
 router.get('*', (req, res) => {
-  console.log('-->> 4.', req.params)
-
   if (req.params['0'] === '/' || req.params['0'].slice(0, 2) === '..')
     return res.sendFile(HTML_FILE)
   

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -10,7 +10,7 @@ const router = express.Router(),
 app.use(express.static(DIST_DIR))
 
 // Markdown docs
-router.get('/api/posts/:postId', (req, res) => {
+router.get('/api/post/:postId', (req, res) => {
   const content = fs.readFileSync(`./src/content/${req.params.postId}.md`, 'utf8')
 
   res.setHeader('Content-Type', 'application/json')
@@ -20,7 +20,7 @@ router.get('/api/posts/:postId', (req, res) => {
 // Main pages - e.g. /page/about
 router.get('/page/:page', (req, res) => { res.sendFile(HTML_FILE) })
 
-// Post pages - e.g. /posts/redux
+// Post pages - e.g. /post/redux
 router.get('/post/:post', (req, res) => { res.sendFile(HTML_FILE) })
 
 // Assets from the Dist folder - e.g. font files

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -17,11 +17,11 @@ router.get('/api/posts/:postId', (req, res) => {
   res.json(content)
 })
 
-// Main pages - e.g. /about
+// Main pages - e.g. /page/about
 router.get('/page/:page', (req, res) => { res.sendFile(HTML_FILE) })
 
 // Post pages - e.g. /posts/redux
-router.get('/posts/:post', (req, res) => { res.sendFile(HTML_FILE) })
+router.get('/post/:post', (req, res) => { res.sendFile(HTML_FILE) })
 
 // Assets from the Dist folder - e.g. font files
 router.get('*', (req, res) => {


### PR DESCRIPTION
Previously, page refresh would not render components, because we were setting the matching param in the Route dynamically, which did not fly. All Route matching must happen explicitly - i.e. not using variables. 

This PR also fixes the back-end node router for production, which was previously serving incorrect pages and assets. 